### PR TITLE
[#2] 공통 응답/예외 처리 기반 구조 구현

### DIFF
--- a/src/main/java/com/soar_be/global/dto/ApiResponse.java
+++ b/src/main/java/com/soar_be/global/dto/ApiResponse.java
@@ -1,0 +1,32 @@
+package com.soar_be.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private boolean success;
+    private String message;
+    private T data;
+    private String errorCode;   // 👈 추가
+
+    private static final String SUCCESS_MSG = "요청이 성공적으로 처리되었습니다.";
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, SUCCESS_MSG, data, null);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(false, message, null, null);
+    }
+
+    public static <T> ApiResponse<T> error(String message, String errorCode) {
+        return new ApiResponse<>(false, message, null, errorCode);
+    }
+}

--- a/src/main/java/com/soar_be/global/exception/CustomException.java
+++ b/src/main/java/com/soar_be/global/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.soar_be.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(final ErrorCode errorCode, final String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/soar_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/soar_be/global/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.soar_be.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 잘못되었습니다."),
+    
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/soar_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/soar_be/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.soar_be.global.exception;
+
+import com.soar_be.global.dto.ApiResponse;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    private static final String CUSTOM_EXCEPTION_LOG_HEADER = "CustomException: {}";
+    private static final String VALIDATION_EXCEPTION_LOG_HEADER = "ValidationException: {}";
+    private static final String GENERAL_EXCEPTION_LOG_HEADER = "Unexpected error: {}";
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException exception) {
+        log.error(CUSTOM_EXCEPTION_LOG_HEADER, exception.getMessage(), exception);
+        return ResponseEntity.status(exception.getErrorCode().getHttpStatus())
+                .body(ApiResponse.error(exception.getMessage(), exception.getErrorCode().name()));
+
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception) {
+        String message = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        log.error(VALIDATION_EXCEPTION_LOG_HEADER, message);
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error(message, ErrorCode.INVALID_INPUT.name()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(Exception exception) {
+        log.error(GENERAL_EXCEPTION_LOG_HEADER, exception.getMessage(), exception);
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+                        ErrorCode.INTERNAL_SERVER_ERROR.name()));
+
+    }
+}
+


### PR DESCRIPTION
## 📌 개요

공통 응답 포맷(ApiResponse)과 글로벌 예외 처리(GlobalExceptionHandler, CustomException, ErrorCode)를 구축하여
프로젝트 전체에서 일관된 API 응답 구조와 예외 핸들링 방식을 제공하도록 구현함.

---

## 🛠 작업 내용
구체적으로 어떤 항목을 개발했는지 체크해주세요.

- [ ] API 엔드포인트 추가
- [ ] Controller 구현
- [ ] Service 비즈니스 로직 구현
- [ ] Repository/JPA 구현
- [ ] Entity/DTO 추가
- [x] 예외 처리 추가
- [ ] 테스트 코드 작성
- [ ] Swagger 문서화
- [x] 기타 리팩토링: 공통 인프라 기반 구축 

---

## 🔍 주요 변경 사항 설명
### ApiResponse<T>
- 모든 API 응답을 success/message/data 형태로 통일
- success() / error() 정적 팩토리 메서드로 가독성과 재사용성 향상

### CustomException & ErrorCode
- 서비스 전역 오류를 Enum 기반으로 관리
- HttpStatus + 메시지를 한 번에 관리하여 확장성 확보

### GlobalExceptionHandler
- CustomException, ValidationException(MethodArgumentNotValidException), 일반 Exception을 각각 처리
- 공통적인 에러 로그 포맷 유지 (error-level logging)
---

## 📸 실행/테스트 결과 (Optional)
### 정상 응답 예 
```json
{
  "success": true,
  "message": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "userId": 1,
    "email": "test@example.com",
    "name": "다현"
  }
}
```

### 예외 응답 예 
```json
{
  "success": false,
  "message": "서버 내부 오류가 발생했습니다.",
  "data": null
}
```


---

## 🔗 관련 이슈
- Resolves: #2 
