### PR TITLE
[#9] Ranking 기능 구현 (순위 수집, 조회, 분석)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ ext {
 }
 
 dependencies {
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
+    
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/soar_be/config/RestTemplateConfig.java
+++ b/src/main/java/com/soar_be/config/RestTemplateConfig.java
@@ -1,8 +1,9 @@
 package com.soar_be.config;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -10,10 +11,16 @@ public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(5000);
-        factory.setReadTimeout(10000);
-
-        return new RestTemplate(factory);
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setInterceptors(Collections.singletonList(
+                (request, body, execution) -> {
+                    System.out.println("=== Actual Request ===");
+                    System.out.println("URI: " + request.getURI());
+                    System.out.println("Headers: " + request.getHeaders());
+                    System.out.println("Body: " + new String(body, StandardCharsets.UTF_8));
+                    return execution.execute(request, body);
+                }
+        ));
+        return restTemplate;
     }
 }

--- a/src/main/java/com/soar_be/config/RestTemplateConfig.java
+++ b/src/main/java/com/soar_be/config/RestTemplateConfig.java
@@ -1,0 +1,19 @@
+package com.soar_be.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(10000);
+
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/soar_be/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/soar_be/domain/product/dto/ProductDetailResponse.java
@@ -19,6 +19,7 @@ public class ProductDetailResponse {
     private String registeredName;
     private String actualProductName;
     private String primaryKeyword;
+    private String productUrl;
     private String marketplace;
     private LocalDate registeredDate;
     private ProductStatus status;
@@ -34,6 +35,7 @@ public class ProductDetailResponse {
                 .registeredName(product.getRegisteredName())
                 .actualProductName(product.getActualProductName())
                 .primaryKeyword(product.getPrimaryKeyword())
+                .productUrl(product.getProductUrl())
                 .marketplace(product.getMarketplace())
                 .registeredDate(product.getRegisteredDate())
                 .status(product.getStatus())

--- a/src/main/java/com/soar_be/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/soar_be/domain/product/dto/ProductListResponse.java
@@ -42,10 +42,11 @@ public class ProductListResponse {
         private String registeredName;
         private String actualProductName;
         private String primaryKeyword;
+        private String productUrl;
         private String marketplace;
         private LocalDate registeredDate;
         private ProductStatus status;
-        private LatestRank latestRank;  // null 가능 (순위 데이터 없을 수 있음)
+        private LatestRank latestRank;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
 
@@ -57,6 +58,7 @@ public class ProductListResponse {
                     .registeredName(product.getRegisteredName())
                     .actualProductName(product.getActualProductName())
                     .primaryKeyword(product.getPrimaryKeyword())
+                    .productUrl(product.getProductUrl())
                     .marketplace(product.getMarketplace())
                     .registeredDate(product.getRegisteredDate())
                     .status(product.getStatus())

--- a/src/main/java/com/soar_be/domain/product/dto/ProductRequest.java
+++ b/src/main/java/com/soar_be/domain/product/dto/ProductRequest.java
@@ -27,6 +27,9 @@ public class ProductRequest {
     @NotBlank(message = "키워드는 필수입니다.")
     private String primaryKeyword;
 
+    @NotBlank(message = "상품Url는 필수입니다.")
+    private String productUrl;
+
     @NotBlank(message = "판매처는 필수입니다.")
     private String marketplace;
 

--- a/src/main/java/com/soar_be/domain/product/dto/ProductResponse.java
+++ b/src/main/java/com/soar_be/domain/product/dto/ProductResponse.java
@@ -19,6 +19,7 @@ public class ProductResponse {
     private String registeredName;
     private String actualProductName;
     private String primaryKeyword;
+    private String productUrl;
     private String marketplace;
     private LocalDate registeredDate;
     private ProductStatus status;
@@ -33,6 +34,7 @@ public class ProductResponse {
                 .registeredName(product.getRegisteredName())
                 .actualProductName(product.getActualProductName())
                 .primaryKeyword(product.getPrimaryKeyword())
+                .productUrl(product.getProductUrl())
                 .marketplace(product.getMarketplace())
                 .registeredDate(product.getRegisteredDate())
                 .status(product.getStatus())

--- a/src/main/java/com/soar_be/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/soar_be/domain/product/dto/ProductUpdateRequest.java
@@ -16,6 +16,8 @@ public class ProductUpdateRequest {
 
     private String primaryKeyword;
 
+    private String productUrl;
+
     private String marketplace;
 
     private LocalDate registeredDate;

--- a/src/main/java/com/soar_be/domain/product/entity/Product.java
+++ b/src/main/java/com/soar_be/domain/product/entity/Product.java
@@ -55,6 +55,9 @@ public class Product {
     @Column(name = "primary_keyword", nullable = false, length = 200)
     private String primaryKeyword;
 
+    @Column(name = "product_url", length = 1000)
+    private String productUrl;
+
     @Column(nullable = false, length = 50)
     private String marketplace = "스마트스토어";
 
@@ -93,7 +96,7 @@ public class Product {
     }
 
     public void update(String registeredName, String actualProductName,
-                       String primaryKeyword, String marketplace, LocalDate registeredDate) {
+                       String primaryKeyword, String productUrl, String marketplace, LocalDate registeredDate) {
         if (registeredName != null) {
             this.registeredName = registeredName;
         }
@@ -102,6 +105,9 @@ public class Product {
         }
         if (primaryKeyword != null) {
             this.primaryKeyword = primaryKeyword;
+        }
+        if (productUrl != null) {
+            this.productUrl = productUrl;
         }
         if (marketplace != null) {
             this.marketplace = marketplace;

--- a/src/main/java/com/soar_be/domain/product/service/ExcelColumn.java
+++ b/src/main/java/com/soar_be/domain/product/service/ExcelColumn.java
@@ -5,8 +5,9 @@ public enum ExcelColumn {
     REGISTERED_NAME(1, "등록 상품명"),
     ACTUAL_PRODUCT_NAME(2, "상품명"),
     PRIMARY_KEYWORD(3, "키워드"),
-    MARKETPLACE(4, "판매처"),
-    REGISTERED_DATE(5, "등록일");
+    PRODUCT_URL(4, "상품URL"),
+    MARKETPLACE(5, "판매처"),
+    REGISTERED_DATE(6, "등록일");
 
     private final int index;
     private final String displayName;

--- a/src/main/java/com/soar_be/domain/product/service/ExcelParsingService.java
+++ b/src/main/java/com/soar_be/domain/product/service/ExcelParsingService.java
@@ -89,6 +89,7 @@ public class ExcelParsingService {
         String registeredName = getCellValue(row, ExcelColumn.REGISTERED_NAME.getIndex());
         String actualProductName = getCellValue(row, ExcelColumn.ACTUAL_PRODUCT_NAME.getIndex());
         String primaryKeyword = getCellValue(row, ExcelColumn.PRIMARY_KEYWORD.getIndex());
+        String productUrl = getCellValue(row, ExcelColumn.PRODUCT_URL.getIndex());
         String marketplace = getCellValue(row, ExcelColumn.MARKETPLACE.getIndex());
         String registeredDateStr = getCellValue(row, ExcelColumn.REGISTERED_DATE.getIndex());
 
@@ -96,6 +97,7 @@ public class ExcelParsingService {
         validateRequiredField(registeredName, ExcelColumn.REGISTERED_NAME, rowNum);
         validateRequiredField(actualProductName, ExcelColumn.ACTUAL_PRODUCT_NAME, rowNum);
         validateRequiredField(primaryKeyword, ExcelColumn.PRIMARY_KEYWORD, rowNum);
+        validateRequiredField(productUrl, ExcelColumn.PRODUCT_URL, rowNum);
         validateRequiredField(marketplace, ExcelColumn.MARKETPLACE, rowNum);
 
         LocalDate registeredDate = parseRegisteredDate(registeredDateStr);
@@ -106,6 +108,7 @@ public class ExcelParsingService {
                 .registeredName(registeredName.trim())
                 .actualProductName(actualProductName.trim())
                 .primaryKeyword(primaryKeyword.trim())
+                .productUrl(productUrl.trim())
                 .marketplace(marketplace.trim())
                 .registeredDate(registeredDate)
                 .status(ProductStatus.ACTIVE)

--- a/src/main/java/com/soar_be/domain/product/service/ProductService.java
+++ b/src/main/java/com/soar_be/domain/product/service/ProductService.java
@@ -110,6 +110,7 @@ public class ProductService {
                 .registeredName(request.getRegisteredName())
                 .actualProductName(request.getActualProductName())
                 .primaryKeyword(request.getPrimaryKeyword())
+                .productUrl(request.getProductUrl())
                 .marketplace(request.getMarketplace())
                 .registeredDate(request.getRegisteredDate())
                 .status(ProductStatus.ACTIVE)
@@ -176,6 +177,7 @@ public class ProductService {
                 request.getRegisteredName(),
                 request.getActualProductName(),
                 request.getPrimaryKeyword(),
+                request.getProductUrl(),
                 request.getMarketplace(),
                 request.getRegisteredDate()
         );

--- a/src/main/java/com/soar_be/domain/ranking/api/RankingAPI.java
+++ b/src/main/java/com/soar_be/domain/ranking/api/RankingAPI.java
@@ -1,0 +1,32 @@
+package com.soar_be.domain.ranking.api;
+
+import com.soar_be.auth.details.CustomUserDetails;
+import com.soar_be.domain.ranking.dto.RankingDashboardResponse;
+import com.soar_be.domain.ranking.dto.RankingFetchResponse;
+import com.soar_be.domain.ranking.dto.RankingHistoryResponse;
+import com.soar_be.global.dto.ApiResponse;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface RankingAPI {
+
+    ResponseEntity<ApiResponse<RankingHistoryResponse>> getRankingHistory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("productId") Long productId,
+            @RequestParam(value = "startDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
+            @RequestParam(value = "limit", required = false, defaultValue = "30") Integer limit);
+
+    ResponseEntity<ApiResponse<RankingDashboardResponse>> getRankingDashboard(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("storeId") Long storeId,
+            @RequestParam(value = "date", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date);
+
+    ResponseEntity<ApiResponse<RankingFetchResponse>> fetchRankingManually(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("productId") Long productId);
+}

--- a/src/main/java/com/soar_be/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/soar_be/domain/ranking/controller/RankingController.java
@@ -1,0 +1,88 @@
+package com.soar_be.domain.ranking.controller;
+
+import com.soar_be.auth.details.CustomUserDetails;
+import com.soar_be.domain.ranking.api.RankingAPI;
+import com.soar_be.domain.ranking.dto.RankingDashboardResponse;
+import com.soar_be.domain.ranking.dto.RankingFetchResponse;
+import com.soar_be.domain.ranking.dto.RankingHistoryResponse;
+import com.soar_be.domain.ranking.service.RankingService;
+import com.soar_be.global.dto.ApiResponse;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class RankingController implements RankingAPI {
+
+    private final RankingService rankingService;
+
+    @Override
+    @GetMapping("/products/{productId}/rankings")
+    public ResponseEntity<ApiResponse<RankingHistoryResponse>> getRankingHistory(
+            CustomUserDetails userDetails,
+            @PathVariable("productId") Long productId,
+            @RequestParam(value = "startDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
+            @RequestParam(value = "limit", required = false, defaultValue = "30") Integer limit) {
+
+        log.debug("Ranking history request - userId: {}, productId: {}, startDate: {}, endDate: {}, limit: {}",
+                userDetails.getUserId(), productId, startDate, endDate, limit);
+
+        ApiResponse<RankingHistoryResponse> response = rankingService.getRankingHistory(
+                userDetails.getUserId(),
+                productId,
+                startDate,
+                endDate,
+                limit
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/stores/{storeId}/rankings/dashboard")
+    public ResponseEntity<ApiResponse<RankingDashboardResponse>> getRankingDashboard(
+            CustomUserDetails userDetails,
+            @PathVariable("storeId") Long storeId,
+            @RequestParam(value = "date", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+        log.debug("Dashboard request - userId: {}, storeId: {}, date: {}",
+                userDetails.getUserId(), storeId, date);
+
+        ApiResponse<RankingDashboardResponse> response = rankingService.getRankingDashboard(
+                userDetails.getUserId(),
+                storeId,
+                date
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @PostMapping("/products/{productId}/rankings/fetch")
+    public ResponseEntity<ApiResponse<RankingFetchResponse>> fetchRankingManually(
+            CustomUserDetails userDetails,
+            @PathVariable("productId") Long productId) {
+
+        log.debug("Manual ranking fetch request - userId: {}, productId: {}",
+                userDetails.getUserId(), productId);
+
+        ApiResponse<RankingFetchResponse> response = rankingService.fetchRankingManually(
+                userDetails.getUserId(),
+                productId
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/soar_be/domain/ranking/dto/DashboardProductItem.java
+++ b/src/main/java/com/soar_be/domain/ranking/dto/DashboardProductItem.java
@@ -1,0 +1,43 @@
+package com.soar_be.domain.ranking.dto;
+
+import com.soar_be.domain.ranking.entity.ChangeTrend;
+import com.soar_be.domain.ranking.entity.Ranking;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DashboardProductItem {
+
+    private Long productId;
+    private String managementCode;
+    private String registeredName;
+    private String keyword;
+    private Integer currentRank;
+    private Integer previousRank;
+    private ChangeTrend changeTrend;
+    private Integer changeAmount;
+    private Boolean isVisible;
+
+
+    public static DashboardProductItem from(Ranking ranking) {
+        Integer changeAmount = null;
+        if (ranking.getPreviousRank() != null && ranking.getRankOverall() != null) {
+            changeAmount = ranking.getPreviousRank() - ranking.getRankOverall();
+        }
+
+        return DashboardProductItem.builder()
+                .productId(ranking.getProduct().getId())
+                .managementCode(ranking.getProduct().getManagementCode())
+                .registeredName(ranking.getProduct().getRegisteredName())
+                .keyword(ranking.getProduct().getPrimaryKeyword())
+                .currentRank(ranking.getRankOverall())
+                .previousRank(ranking.getPreviousRank())
+                .changeTrend(ranking.getChangeTrend())
+                .changeAmount(changeAmount)
+                .isVisible(ranking.getIsVisible())
+                .build();
+    }
+}

--- a/src/main/java/com/soar_be/domain/ranking/dto/DashboardSummary.java
+++ b/src/main/java/com/soar_be/domain/ranking/dto/DashboardSummary.java
@@ -1,0 +1,17 @@
+package com.soar_be.domain.ranking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DashboardSummary {
+    private Integer totalProducts;
+    private Integer upCount;
+    private Integer downCount;
+    private Integer sameCount;
+    private Integer newCount;
+    private Integer lostCount;
+}

--- a/src/main/java/com/soar_be/domain/ranking/dto/RankingDashboardResponse.java
+++ b/src/main/java/com/soar_be/domain/ranking/dto/RankingDashboardResponse.java
@@ -1,0 +1,30 @@
+package com.soar_be.domain.ranking.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RankingDashboardResponse {
+
+    private Long storeId;
+    private LocalDate date;
+    private DashboardSummary summary;
+    private List<DashboardProductItem> products;
+
+
+    public static RankingDashboardResponse of(Long storeId, LocalDate date,
+                                              DashboardSummary summary,
+                                              List<DashboardProductItem> products) {
+        return RankingDashboardResponse.builder()
+                .storeId(storeId)
+                .date(date)
+                .summary(summary)
+                .products(products)
+                .build();
+    }
+}

--- a/src/main/java/com/soar_be/domain/ranking/dto/RankingFetchResponse.java
+++ b/src/main/java/com/soar_be/domain/ranking/dto/RankingFetchResponse.java
@@ -1,0 +1,21 @@
+package com.soar_be.domain.ranking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RankingFetchResponse {
+
+    private Long productId;
+    private String status;
+
+    public static RankingFetchResponse inProgress(Long productId) {
+        return RankingFetchResponse.builder()
+                .productId(productId)
+                .status("IN_PROGRESS")
+                .build();
+    }
+}

--- a/src/main/java/com/soar_be/domain/ranking/dto/RankingHistoryResponse.java
+++ b/src/main/java/com/soar_be/domain/ranking/dto/RankingHistoryResponse.java
@@ -1,0 +1,32 @@
+package com.soar_be.domain.ranking.dto;
+
+import com.soar_be.domain.ranking.entity.Ranking;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RankingHistoryResponse {
+    private Long productId;
+    private String productName;
+    private String keyword;
+    private List<RankingResponse> rankings;
+    private RankingSummary summary;
+
+    public static RankingHistoryResponse from(Long productId, String productName,
+                                              String keyword, List<Ranking> rankings,
+                                              RankingSummary summary) {
+        return RankingHistoryResponse.builder()
+                .productId(productId)
+                .productName(productName)
+                .keyword(keyword)
+                .rankings(rankings.stream()
+                        .map(RankingResponse::from)
+                        .toList())
+                .summary(summary)
+                .build();
+    }
+}

--- a/src/main/java/com/soar_be/domain/ranking/dto/RankingResponse.java
+++ b/src/main/java/com/soar_be/domain/ranking/dto/RankingResponse.java
@@ -1,0 +1,34 @@
+package com.soar_be.domain.ranking.dto;
+
+import com.soar_be.domain.ranking.entity.ChangeTrend;
+import com.soar_be.domain.ranking.entity.Ranking;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RankingResponse {
+
+    private Long rankingId;
+    private Integer rankOverall;
+    private Integer rankPage;
+    private Boolean isVisible;
+    private ChangeTrend changeTrend;
+    private Integer previousRank;
+    private LocalDateTime createdAt;
+
+    public static RankingResponse from(Ranking ranking) {
+        return RankingResponse.builder()
+                .rankingId(ranking.getId())
+                .rankOverall(ranking.getRankOverall())
+                .rankPage(ranking.getRankPage())
+                .isVisible(ranking.getIsVisible())
+                .changeTrend(ranking.getChangeTrend())
+                .previousRank(ranking.getPreviousRank())
+                .createdAt(ranking.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/soar_be/domain/ranking/dto/RankingSummary.java
+++ b/src/main/java/com/soar_be/domain/ranking/dto/RankingSummary.java
@@ -1,0 +1,17 @@
+package com.soar_be.domain.ranking.dto;
+
+import com.soar_be.domain.ranking.entity.ChangeTrend;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RankingSummary {
+    private Integer currentRank;
+    private Integer highestRank;
+    private Integer lowestRank;
+    private Double averageRank;
+    private ChangeTrend trend;
+}

--- a/src/main/java/com/soar_be/domain/ranking/entity/Ranking.java
+++ b/src/main/java/com/soar_be/domain/ranking/entity/Ranking.java
@@ -31,9 +31,6 @@ public class Ranking {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 200)
-    private String keyword;
-
     @Column(name = "rank_overall")
     private Integer rankOverall;
 
@@ -60,5 +57,9 @@ public class Ranking {
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
+    }
+
+    public String getKeyword() {
+        return product.getPrimaryKeyword();
     }
 }

--- a/src/main/java/com/soar_be/domain/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/soar_be/domain/ranking/repository/RankingRepository.java
@@ -1,0 +1,45 @@
+package com.soar_be.domain.ranking.repository;
+
+import com.soar_be.domain.ranking.entity.Ranking;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RankingRepository extends JpaRepository<Ranking, Long> {
+    
+    Optional<Ranking> findTopByProductIdOrderByCreatedAtDesc(Long productId);
+
+    @Query("SELECT r FROM Ranking r WHERE r.product.id = :productId " +
+            "AND r.createdAt BETWEEN :startDate AND :endDate " +
+            "ORDER BY r.createdAt DESC")
+    List<Ranking> findByProductIdAndCreatedAtBetween(
+            @Param("productId") Long productId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
+
+    List<Ranking> findTop30ByProductIdOrderByCreatedAtDesc(Long productId);
+
+    @Query("SELECT r FROM Ranking r " +
+            "JOIN r.product p " +
+            "WHERE p.store.id = :storeId " +
+            "AND DATE(r.createdAt) = DATE(:date) " +
+            "ORDER BY r.createdAt DESC")
+    List<Ranking> findByStoreIdAndDate(
+            @Param("storeId") Long storeId,
+            @Param("date") LocalDateTime date);
+
+    @Query("SELECT r FROM Ranking r " +
+            "WHERE r.id IN (" +
+            "  SELECT MAX(r2.id) FROM Ranking r2 " +
+            "  WHERE r2.product.store.id = :storeId " +
+            "  GROUP BY r2.product.id" +
+            ")")
+    List<Ranking> findLatestByStoreId(@Param("storeId") Long storeId);
+
+    long countByProductId(Long productId);
+}

--- a/src/main/java/com/soar_be/domain/ranking/service/RankingSearchService.java
+++ b/src/main/java/com/soar_be/domain/ranking/service/RankingSearchService.java
@@ -1,0 +1,165 @@
+package com.soar_be.domain.ranking.service;
+
+import com.soar_be.domain.product.entity.Product;
+import com.soar_be.domain.ranking.entity.ChangeTrend;
+import com.soar_be.domain.ranking.entity.Ranking;
+import com.soar_be.domain.ranking.repository.RankingRepository;
+import com.soar_be.infra.naver.NaverShoppingClient;
+import com.soar_be.infra.naver.dto.NaverShoppingItem;
+import com.soar_be.infra.naver.dto.NaverShoppingResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingSearchService {
+
+    private static final int MAX_RANK = 1000;
+    private static final int PAGE_SIZE = 100;
+
+    private final NaverShoppingClient naverShoppingClient;
+    private final RankingRepository rankingRepository;
+
+
+    @Transactional
+    public Ranking searchAndSaveRanking(Product product) {
+        String keyword = product.getPrimaryKeyword();
+        String managementCode = product.getManagementCode();
+        String storeName = product.getStore().getName();
+
+        log.info("Starting rank search - productId: {}, keyword: {}", product.getId(), keyword);
+        log.info("Product details - managementCode: {}, store: {}", managementCode, storeName);
+
+        if (managementCode == null || managementCode.isBlank()) {
+            log.warn("Management code is null or empty for productId: {}", product.getId());
+            return saveRankingAsNotFound(product);
+        }
+
+        Integer foundRank = null;
+
+        for (int start = 1; start <= MAX_RANK; start += PAGE_SIZE) {
+            if (start > 1) {
+                try {
+                    Thread.sleep(200);  // 200ms 대기
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("Sleep interrupted", e);
+                }
+            }
+
+            NaverShoppingResponse response = naverShoppingClient.search(keyword, PAGE_SIZE, start);
+
+            if (response == null || response.getItems() == null) {
+                log.warn("Empty response at start: {}", start);
+                continue;
+            }
+
+            log.debug("Page response - start: {}, total: {}, items: {}",
+                    start, response.getTotal(), response.getItems().size());
+
+            Optional<Integer> matchedIndex = findMatchingProduct(response.getItems(), managementCode);
+
+            if (matchedIndex.isPresent()) {
+                foundRank = start + matchedIndex.get();
+                log.info("Product found - productId: {}, rank: {}", product.getId(), foundRank);
+                break;
+            }
+
+            if (response.getTotal() == 0 || response.getItems().isEmpty()) {
+                log.info("No more results after start: {}", start);
+                break;
+            }
+        }
+
+        Optional<Ranking> previousRanking = rankingRepository.findTopByProductIdOrderByCreatedAtDesc(product.getId());
+
+        ChangeTrend changeTrend = calculateChangeTrend(foundRank, previousRanking);
+        Integer previousRank = previousRanking.map(Ranking::getRankOverall).orElse(null);
+
+        Ranking ranking = Ranking.builder()
+                .product(product)
+                .rankOverall(foundRank)
+                .rankPage(foundRank != null ? (foundRank - 1) / PAGE_SIZE + 1 : null)
+                .isVisible(foundRank != null)
+                .changeTrend(changeTrend)
+                .previousRank(previousRank)
+                .build();
+
+        Ranking savedRanking = rankingRepository.save(ranking);
+
+        log.info("Ranking saved - productId: {}, rank: {}, trend: {}",
+                product.getId(), foundRank, changeTrend);
+
+        return savedRanking;
+    }
+
+    /**
+     * API 응답의 상품 목록에서 관리번호(productId)로 매칭
+     */
+    private Optional<Integer> findMatchingProduct(java.util.List<NaverShoppingItem> items,
+                                                  String managementCode) {
+        if (managementCode == null || managementCode.isBlank()) {
+            log.warn("Management code is null or empty, cannot match product");
+            return Optional.empty();
+        }
+
+        for (int i = 0; i < items.size(); i++) {
+            NaverShoppingItem item = items.get(i);
+
+            if (managementCode.equals(item.getProductId())) {
+                log.debug("Product matched by productId - index: {}, productId: {}, mallName: {}",
+                        i, managementCode, item.getMallName());
+                return Optional.of(i);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * 상품을 찾지 못한 경우 미노출로 저장
+     */
+    private Ranking saveRankingAsNotFound(Product product) {
+        Optional<Ranking> previousRanking = rankingRepository.findTopByProductIdOrderByCreatedAtDesc(product.getId());
+
+        Ranking ranking = Ranking.builder()
+                .product(product)
+                .rankOverall(null)
+                .rankPage(null)
+                .isVisible(false)
+                .changeTrend(ChangeTrend.LOST)
+                .previousRank(previousRanking.map(Ranking::getRankOverall).orElse(null))
+                .build();
+
+        return rankingRepository.save(ranking);
+    }
+
+    private ChangeTrend calculateChangeTrend(Integer currentRank, Optional<Ranking> previousRanking) {
+        if (previousRanking.isEmpty()) {
+            return currentRank != null ? ChangeTrend.NEW : ChangeTrend.LOST;
+        }
+
+        Integer previousRank = previousRanking.get().getRankOverall();
+        Boolean wasPreviousVisible = previousRanking.get().getIsVisible();
+
+        if (currentRank == null) {
+            return wasPreviousVisible ? ChangeTrend.LOST : ChangeTrend.LOST;
+        }
+
+        if (previousRank == null || !wasPreviousVisible) {
+            return ChangeTrend.NEW;
+        }
+
+        if (currentRank < previousRank) {
+            return ChangeTrend.UP;
+        } else if (currentRank > previousRank) {
+            return ChangeTrend.DOWN;
+        } else {
+            return ChangeTrend.SAME;
+        }
+    }
+}

--- a/src/main/java/com/soar_be/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/soar_be/domain/ranking/service/RankingService.java
@@ -1,0 +1,214 @@
+package com.soar_be.domain.ranking.service;
+
+import com.soar_be.domain.product.entity.Product;
+import com.soar_be.domain.product.repository.ProductRepository;
+import com.soar_be.domain.ranking.dto.DashboardProductItem;
+import com.soar_be.domain.ranking.dto.DashboardSummary;
+import com.soar_be.domain.ranking.dto.RankingDashboardResponse;
+import com.soar_be.domain.ranking.dto.RankingFetchResponse;
+import com.soar_be.domain.ranking.dto.RankingHistoryResponse;
+import com.soar_be.domain.ranking.dto.RankingSummary;
+import com.soar_be.domain.ranking.entity.ChangeTrend;
+import com.soar_be.domain.ranking.entity.Ranking;
+import com.soar_be.domain.ranking.repository.RankingRepository;
+import com.soar_be.domain.store.entity.Store;
+import com.soar_be.domain.store.repository.StoreRepository;
+import com.soar_be.global.dto.ApiResponse;
+import com.soar_be.global.exception.CustomException;
+import com.soar_be.global.exception.ErrorCode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final RankingRepository rankingRepository;
+    private final ProductRepository productRepository;
+    private final StoreRepository storeRepository;
+
+    private final RankingSearchService rankingSearchService;
+
+
+    @Transactional(readOnly = true)
+    public ApiResponse<RankingHistoryResponse> getRankingHistory(Long userId, Long productId,
+                                                                 LocalDate startDate, LocalDate endDate,
+                                                                 Integer limit) {
+        Product product = findProductByIdAndValidateOwner(productId, userId);
+
+        LocalDateTime endDateTime = (endDate != null)
+                ? endDate.atTime(LocalTime.MAX)
+                : LocalDateTime.now();
+        LocalDateTime startDateTime = (startDate != null)
+                ? startDate.atStartOfDay()
+                : endDateTime.minusDays(30);
+
+        List<Ranking> rankings;
+        if (limit != null && limit > 0) {
+            rankings = rankingRepository.findTop30ByProductIdOrderByCreatedAtDesc(productId);
+            if (rankings.size() > limit) {
+                rankings = rankings.subList(0, limit);
+            }
+        } else {
+            rankings = rankingRepository.findByProductIdAndCreatedAtBetween(
+                    productId, startDateTime, endDateTime);
+        }
+
+        RankingSummary summary = calculateRankingSummary(rankings);
+
+        log.info("Ranking history retrieved - productId: {}, count: {}", productId, rankings.size());
+
+        RankingHistoryResponse response = RankingHistoryResponse.from(
+                productId,
+                product.getActualProductName(),
+                product.getPrimaryKeyword(),
+                rankings,
+                summary
+        );
+
+        return ApiResponse.success("순위 조회가 완료되었습니다.", response);
+    }
+
+    @Transactional(readOnly = true)
+    public ApiResponse<RankingDashboardResponse> getRankingDashboard(Long userId, Long storeId,
+                                                                     LocalDate date) {
+        Store store = findStoreByIdAndValidateOwner(storeId, userId);
+
+        LocalDate targetDate = (date != null) ? date : LocalDate.now();
+        LocalDateTime targetDateTime = targetDate.atStartOfDay();
+
+        List<Ranking> rankings = rankingRepository.findByStoreIdAndDate(storeId, targetDateTime);
+
+        List<DashboardProductItem> productItems = rankings.stream()
+                .map(DashboardProductItem::from)
+                .toList();
+
+        DashboardSummary summary = calculateDashboardSummary(rankings);
+
+        log.info("Dashboard retrieved - storeId: {}, date: {}, products: {}",
+                storeId, targetDate, productItems.size());
+
+        RankingDashboardResponse response = RankingDashboardResponse.of(
+                storeId, targetDate, summary, productItems);
+
+        return ApiResponse.success("대시보드 조회가 완료되었습니다.", response);
+    }
+
+
+    @Transactional
+    public ApiResponse<RankingFetchResponse> fetchRankingManually(Long userId, Long productId) {
+        Product product = findProductByIdAndValidateOwner(productId, userId);
+
+        Ranking ranking = rankingSearchService.searchAndSaveRanking(product);
+
+        log.info("Manual ranking fetch completed - productId: {}, rank: {}",
+                productId, ranking.getRankOverall());
+
+        RankingFetchResponse response = RankingFetchResponse.inProgress(productId);
+
+        return ApiResponse.success("순위 조회가 시작되었습니다.", response);
+    }
+
+    private RankingSummary calculateRankingSummary(List<Ranking> rankings) {
+        if (rankings.isEmpty()) {
+            return RankingSummary.builder()
+                    .currentRank(null)
+                    .highestRank(null)
+                    .lowestRank(null)
+                    .averageRank(null)
+                    .trend(ChangeTrend.SAME)
+                    .build();
+        }
+
+        List<Integer> visibleRanks = rankings.stream()
+                .filter(Ranking::getIsVisible)
+                .map(Ranking::getRankOverall)
+                .filter(rank -> rank != null)
+                .toList();
+
+        if (visibleRanks.isEmpty()) {
+            return RankingSummary.builder()
+                    .currentRank(null)
+                    .highestRank(null)
+                    .lowestRank(null)
+                    .averageRank(null)
+                    .trend(ChangeTrend.LOST)
+                    .build();
+        }
+
+        Integer currentRank = rankings.get(0).getRankOverall();
+        Integer highestRank = visibleRanks.stream().min(Integer::compareTo).orElse(null);
+        Integer lowestRank = visibleRanks.stream().max(Integer::compareTo).orElse(null);
+        Double averageRank = visibleRanks.stream()
+                .mapToInt(Integer::intValue)
+                .average()
+                .orElse(0.0);
+
+        ChangeTrend trend = rankings.get(0).getChangeTrend();
+
+        return RankingSummary.builder()
+                .currentRank(currentRank)
+                .highestRank(highestRank)
+                .lowestRank(lowestRank)
+                .averageRank(Math.round(averageRank * 10) / 10.0)
+                .trend(trend)
+                .build();
+    }
+
+    private DashboardSummary calculateDashboardSummary(List<Ranking> rankings) {
+        int totalProducts = rankings.size();
+        int upCount = 0;
+        int downCount = 0;
+        int sameCount = 0;
+        int newCount = 0;
+        int lostCount = 0;
+
+        for (Ranking ranking : rankings) {
+            switch (ranking.getChangeTrend()) {
+                case UP -> upCount++;
+                case DOWN -> downCount++;
+                case SAME -> sameCount++;
+                case NEW -> newCount++;
+                case LOST -> lostCount++;
+            }
+        }
+
+        return DashboardSummary.builder()
+                .totalProducts(totalProducts)
+                .upCount(upCount)
+                .downCount(downCount)
+                .sameCount(sameCount)
+                .newCount(newCount)
+                .lostCount(lostCount)
+                .build();
+    }
+
+    private Product findProductByIdAndValidateOwner(Long productId, Long userId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!product.getStore().getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.STORE_ACCESS_DENIED);
+        }
+
+        return product;
+    }
+
+    private Store findStoreByIdAndValidateOwner(Long storeId, Long userId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+
+        if (!store.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.STORE_ACCESS_DENIED);
+        }
+
+        return store;
+    }
+}

--- a/src/main/java/com/soar_be/infra/naver/NaverApiProperties.java
+++ b/src/main/java/com/soar_be/infra/naver/NaverApiProperties.java
@@ -1,0 +1,17 @@
+package com.soar_be.infra.naver;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "naver.api")
+@Getter
+@Setter
+public class NaverApiProperties {
+
+    private String clientId;
+    private String clientSecret;
+    private String baseUrl;
+}

--- a/src/main/java/com/soar_be/infra/naver/NaverShoppingClient.java
+++ b/src/main/java/com/soar_be/infra/naver/NaverShoppingClient.java
@@ -1,143 +1,104 @@
 package com.soar_be.infra.naver;
 
-import com.soar_be.infra.naver.dto.NaverShoppingItem;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.soar_be.infra.naver.dto.NaverShoppingResponse;
-import java.net.URI;
-import java.net.URLEncoder;
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import lombok.RequiredArgsConstructor;
+import java.util.zip.GZIPInputStream;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.RequestEntity;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class NaverShoppingClient {
 
-    private final NaverApiProperties naverApiProperties;
     private final RestTemplate restTemplate;
+    private final String clientId;
+    private final String clientSecret;
+    private final String apiUrl;
 
-    private static final int DISPLAY_SIZE = 100;
-    private static final int MAX_START = 1001;
-    private static final String SEARCH_PATH = "/v1/search/shop.json";
+    public NaverShoppingClient(
+            RestTemplate restTemplate,
+            @Value("${naver.api.client-id}") String clientId,
+            @Value("${naver.api.client-secret}") String clientSecret,
+            @Value("${naver.api.shopping-url}") String apiUrl) {
+        this.restTemplate = restTemplate;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.apiUrl = apiUrl;
+    }
 
-    public Optional<NaverShoppingResponse> search(String keyword, int start) {
+    public NaverShoppingResponse search(String query, int display, int start) {
+        log.warn("🔍 Received query parameter: [{}], length: {}", query, query.length());
+
+        String url = UriComponentsBuilder.fromHttpUrl(apiUrl)
+                .queryParam("query", query)
+                .queryParam("display", display)
+                .queryParam("exclude", "used:rental:cbshop")
+                .queryParam("start", start)
+                .build()
+                .toUriString();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id", clientId);
+        headers.set("X-Naver-Client-Secret", clientSecret);
+        headers.set("User-Agent", "Mozilla/5.0");
+        headers.set("Accept-Encoding", "gzip");
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
         try {
-            String encodedKeyword = URLEncoder.encode(keyword, StandardCharsets.UTF_8);
-            String url = String.format("%s%s?query=%s&display=%d&start=%d&sort=sim",
-                    naverApiProperties.getBaseUrl(),
-                    SEARCH_PATH,
-                    encodedKeyword,
-                    DISPLAY_SIZE,
-                    start);
-
-            RequestEntity<Void> request = RequestEntity
-                    .get(URI.create(url))
-                    .header("X-Naver-Client-Id", naverApiProperties.getClientId())
-                    .header("X-Naver-Client-Secret", naverApiProperties.getClientSecret())
-                    .build();
-
-            ResponseEntity<NaverShoppingResponse> response = restTemplate.exchange(
-                    request,
-                    NaverShoppingResponse.class
+            ResponseEntity<byte[]> rawResponse = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    byte[].class
             );
 
-            return Optional.ofNullable(response.getBody());
+            log.warn("🚨 Naver API Request URL: {}", url);
 
-        } catch (RestClientException e) {
-            log.error("네이버 쇼핑 API 호출 실패 - keyword: {}, start: {}, error: {}",
-                    keyword, start, e.getMessage());
-            return Optional.empty();
-        }
-    }
+            HttpHeaders respHeaders = rawResponse.getHeaders();
+            String contentEncoding = respHeaders.getFirst("Content-Encoding");
+            String contentType = respHeaders.getFirst("Content-Type");
+            byte[] bodyBytes = rawResponse.getBody();
 
-    public List<NaverShoppingItem> searchAll(String keyword) {
-        List<NaverShoppingItem> allItems = new ArrayList<>();
+            log.warn("📦 Response headers - Content-Type: {}, Content-Encoding: {}",
+                    contentType, contentEncoding);
+            log.warn("📦 Response body length: {}", bodyBytes != null ? bodyBytes.length : 0);
 
-        for (int start = 1; start <= MAX_START; start += DISPLAY_SIZE) {
-            Optional<NaverShoppingResponse> response = search(keyword, start);
-
-            if (response.isEmpty() || response.get().isEmpty()) {
-                log.debug("검색 결과 없음 - keyword: {}, start: {}", keyword, start);
-                break;
+            if (bodyBytes == null || bodyBytes.length == 0) {
+                log.error("Empty body from Naver API");
+                throw new RuntimeException("네이버 쇼핑 API 응답이 비어 있습니다.");
             }
 
-            NaverShoppingResponse data = response.get();
-            allItems.addAll(data.getItems());
-
-            if (data.getItemCount() < DISPLAY_SIZE) {
-                break;
+            String bodyString;
+            if (contentEncoding != null && contentEncoding.equalsIgnoreCase("gzip")) {
+                try (GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(bodyBytes))) {
+                    byte[] uncompressed = gis.readAllBytes();
+                    bodyString = new String(uncompressed, StandardCharsets.UTF_8);
+                }
+            } else {
+                bodyString = new String(bodyBytes, StandardCharsets.UTF_8);
             }
 
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
+            String preview = bodyString.length() > 1000
+                    ? bodyString.substring(0, 1000) + "...(truncated)"
+                    : bodyString;
+            log.warn("🔎 Naver API RAW response text (start={}): {}", start, preview);
+
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(bodyString, NaverShoppingResponse.class);
+
+        } catch (Exception e) {
+            log.error("Naver Shopping API call failed - query: {}, start: {}", query, start, e);
+            throw new RuntimeException("네이버 쇼핑 API 호출에 실패했습니다.", e);
         }
-
-        log.info("네이버 쇼핑 검색 완료 - keyword: {}, 총 {}개 결과", keyword, allItems.size());
-        return allItems;
-    }
-
-    public Optional<Integer> findRankByProductUrl(String keyword, String productUrl) {
-        List<NaverShoppingItem> items = searchAll(keyword);
-
-        for (int i = 0; i < items.size(); i++) {
-            NaverShoppingItem item = items.get(i);
-            if (item.getLink() != null && item.getLink().contains(extractProductId(productUrl))) {
-                int rank = i + 1;
-                log.debug("상품 순위 발견 - keyword: {}, rank: {}", keyword, rank);
-                return Optional.of(rank);
-            }
-        }
-
-        log.debug("상품 미노출 - keyword: {}, productUrl: {}", keyword, productUrl);
-        return Optional.empty();
-    }
-
-    public Optional<Integer> findRankByMallAndProductId(String keyword, String mallName, String productId) {
-        List<NaverShoppingItem> items = searchAll(keyword);
-
-        for (int i = 0; i < items.size(); i++) {
-            NaverShoppingItem item = items.get(i);
-
-            boolean mallMatch = mallName != null && mallName.equals(item.getMallName());
-            boolean productMatch = productId != null &&
-                    item.getLink() != null &&
-                    item.getLink().contains(productId);
-
-            if (mallMatch && productMatch) {
-                int rank = i + 1;
-                log.debug("상품 순위 발견 - keyword: {}, mallName: {}, rank: {}", keyword, mallName, rank);
-                return Optional.of(rank);
-            }
-        }
-
-        log.debug("상품 미노출 - keyword: {}, mallName: {}, productId: {}", keyword, mallName, productId);
-        return Optional.empty();
-    }
-
-    private String extractProductId(String productUrl) {
-        if (productUrl == null || productUrl.isEmpty()) {
-            return "";
-        }
-
-        if (productUrl.contains("/products/")) {
-            String[] parts = productUrl.split("/products/");
-            if (parts.length > 1) {
-                return parts[1].split("\\?")[0];
-            }
-        }
-
-        return productUrl;
     }
 }

--- a/src/main/java/com/soar_be/infra/naver/NaverShoppingClient.java
+++ b/src/main/java/com/soar_be/infra/naver/NaverShoppingClient.java
@@ -1,0 +1,143 @@
+package com.soar_be.infra.naver;
+
+import com.soar_be.infra.naver.dto.NaverShoppingItem;
+import com.soar_be.infra.naver.dto.NaverShoppingResponse;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverShoppingClient {
+
+    private final NaverApiProperties naverApiProperties;
+    private final RestTemplate restTemplate;
+
+    private static final int DISPLAY_SIZE = 100;
+    private static final int MAX_START = 1001;
+    private static final String SEARCH_PATH = "/v1/search/shop.json";
+
+    public Optional<NaverShoppingResponse> search(String keyword, int start) {
+        try {
+            String encodedKeyword = URLEncoder.encode(keyword, StandardCharsets.UTF_8);
+            String url = String.format("%s%s?query=%s&display=%d&start=%d&sort=sim",
+                    naverApiProperties.getBaseUrl(),
+                    SEARCH_PATH,
+                    encodedKeyword,
+                    DISPLAY_SIZE,
+                    start);
+
+            RequestEntity<Void> request = RequestEntity
+                    .get(URI.create(url))
+                    .header("X-Naver-Client-Id", naverApiProperties.getClientId())
+                    .header("X-Naver-Client-Secret", naverApiProperties.getClientSecret())
+                    .build();
+
+            ResponseEntity<NaverShoppingResponse> response = restTemplate.exchange(
+                    request,
+                    NaverShoppingResponse.class
+            );
+
+            return Optional.ofNullable(response.getBody());
+
+        } catch (RestClientException e) {
+            log.error("네이버 쇼핑 API 호출 실패 - keyword: {}, start: {}, error: {}",
+                    keyword, start, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    public List<NaverShoppingItem> searchAll(String keyword) {
+        List<NaverShoppingItem> allItems = new ArrayList<>();
+
+        for (int start = 1; start <= MAX_START; start += DISPLAY_SIZE) {
+            Optional<NaverShoppingResponse> response = search(keyword, start);
+
+            if (response.isEmpty() || response.get().isEmpty()) {
+                log.debug("검색 결과 없음 - keyword: {}, start: {}", keyword, start);
+                break;
+            }
+
+            NaverShoppingResponse data = response.get();
+            allItems.addAll(data.getItems());
+
+            if (data.getItemCount() < DISPLAY_SIZE) {
+                break;
+            }
+
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        log.info("네이버 쇼핑 검색 완료 - keyword: {}, 총 {}개 결과", keyword, allItems.size());
+        return allItems;
+    }
+
+    public Optional<Integer> findRankByProductUrl(String keyword, String productUrl) {
+        List<NaverShoppingItem> items = searchAll(keyword);
+
+        for (int i = 0; i < items.size(); i++) {
+            NaverShoppingItem item = items.get(i);
+            if (item.getLink() != null && item.getLink().contains(extractProductId(productUrl))) {
+                int rank = i + 1;
+                log.debug("상품 순위 발견 - keyword: {}, rank: {}", keyword, rank);
+                return Optional.of(rank);
+            }
+        }
+
+        log.debug("상품 미노출 - keyword: {}, productUrl: {}", keyword, productUrl);
+        return Optional.empty();
+    }
+
+    public Optional<Integer> findRankByMallAndProductId(String keyword, String mallName, String productId) {
+        List<NaverShoppingItem> items = searchAll(keyword);
+
+        for (int i = 0; i < items.size(); i++) {
+            NaverShoppingItem item = items.get(i);
+
+            boolean mallMatch = mallName != null && mallName.equals(item.getMallName());
+            boolean productMatch = productId != null &&
+                    item.getLink() != null &&
+                    item.getLink().contains(productId);
+
+            if (mallMatch && productMatch) {
+                int rank = i + 1;
+                log.debug("상품 순위 발견 - keyword: {}, mallName: {}, rank: {}", keyword, mallName, rank);
+                return Optional.of(rank);
+            }
+        }
+
+        log.debug("상품 미노출 - keyword: {}, mallName: {}, productId: {}", keyword, mallName, productId);
+        return Optional.empty();
+    }
+
+    private String extractProductId(String productUrl) {
+        if (productUrl == null || productUrl.isEmpty()) {
+            return "";
+        }
+
+        if (productUrl.contains("/products/")) {
+            String[] parts = productUrl.split("/products/");
+            if (parts.length > 1) {
+                return parts[1].split("\\?")[0];
+            }
+        }
+
+        return productUrl;
+    }
+}

--- a/src/main/java/com/soar_be/infra/naver/dto/NaverShoppingItem.java
+++ b/src/main/java/com/soar_be/infra/naver/dto/NaverShoppingItem.java
@@ -1,0 +1,42 @@
+package com.soar_be.infra.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverShoppingItem {
+
+    private String title;
+    private String link;
+    private String image;
+    private String lprice;
+    private String hprice;
+    private String mallName;
+    private String productId;
+    private String productType;
+    private String brand;
+    private String maker;
+    private String category1;
+    private String category2;
+    private String category3;
+    private String category4;
+
+    public String extractProductIdFromLink() {
+        if (link == null || link.isEmpty()) {
+            return null;
+        }
+
+        if (link.contains("smartstore.naver.com")) {
+            String[] parts = link.split("/products/");
+            if (parts.length > 1) {
+                String id = parts[1].split("\\?")[0];
+                return id;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/soar_be/infra/naver/dto/NaverShoppingResponse.java
+++ b/src/main/java/com/soar_be/infra/naver/dto/NaverShoppingResponse.java
@@ -1,0 +1,26 @@
+package com.soar_be.infra.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverShoppingResponse {
+
+    private String lastBuildDate;
+    private Integer total;
+    private Integer start;
+    private Integer display;
+    private List<NaverShoppingItem> items;
+
+    public boolean isEmpty() {
+        return items == null || items.isEmpty();
+    }
+    
+    public int getItemCount() {
+        return items == null ? 0 : items.size();
+    }
+}


### PR DESCRIPTION
## 📌 개요
네이버 쇼핑 API를 연동하여 상품 순위 자동 수집 및 모니터링 기능을 구현했습니다.
- 네이버 쇼핑 검색 API 연동 및 순위 수집
- 상품별 순위 이력 조회 및 통계 제공
- 스토어 대시보드 (순위 요약 및 추세 분석)
- 순위 변동 추세 자동 계산 (UP/DOWN/SAME/NEW/LOST)

---

## 🛠 작업 내용
- [x] API 엔드포인트 추가
- [x] Controller 구현
- [x] Service 비즈니스 로직 구현
- [x] Repository/JPA 구현
- [x] Entity/DTO 추가
- [x] 예외 처리 추가
- [ ] 테스트 코드 작성
- [ ] Swagger 문서화
- [x] 기타 리팩토링

---

## 🔍 주요 변경 사항 설명

### 1. URL 인코딩 이슈 해결
- **문제**: `UriComponentsBuilder.encode()`와 `RestTemplate`의 이중 인코딩 발생
- **해결**: `.build()` 사용으로 인코딩 한 번만 수행되도록 수정
- **결과**: 한글 키워드 검색이 정상적으로 동작

### 2. 상품 매칭 방식 변경
- **초기 설계**: `product_url`로 매칭 시도
- **문제**: 네이버 API 응답 URL 형식 차이 (`/daitz-store/products/번호` vs `/main/products/번호`)
- **최종 해결**: `managementCode`와 `NaverShoppingItem.productId` 직접 비교
- **장점**: URL 형식 변경에 영향받지 않고 안정적인 매칭

### 3. Rate Limiting 고려
- API 호출 간 200ms 딜레이 적용하여 안정적인 요청 처리
- GZIP 압축 응답 처리 구현

### 4. 순위 변동 추세 계산 로직
- 이전 순위와 비교하여 자동으로 추세 판단
- 신규 진입(NEW), 미노출(LOST) 케이스 처리
- 대시보드에서 상승/하락 카운트 집계

### 5. 페이지네이션 처리
- 네이버 API의 `start` 파라미터를 활용하여 최대 1000위까지 조회
- `display=100`으로 한 번에 100개씩 페이징 처리

---

## 📸 실행/테스트 결과

### 1. 수동 순위 조회 트리거 테스트 
<img width="598" height="506" alt="image" src="https://github.com/user-attachments/assets/4171f8e2-3d2b-4c45-a486-3157f3455d23" />

### 2. 대시보드 조회 (날짜별 필터링)
- 2025-11-27(오늘) 데이터가 정상적으로 조회됨
- 상품별 순위 및 추세 정보 제공
<img width="738" height="873" alt="image" src="https://github.com/user-attachments/assets/dd748958-b08c-44e5-8739-c8efbf29440b" />

### 3.  상품 순위 조회 
- 해당 상품의 전체 순위 정보 조회 가능 
- 테스트 대상 상품의 경우 전날에 비해 5위 하락한 것도 확인할 수 있음 
<img width="620" height="1007" alt="image" src="https://github.com/user-attachments/assets/184a4019-7467-46d3-9358-cf5ad8a1961d" />


---

## 🔗 관련 이슈
Closes #9 

---

## 📝 추가 작업 필요 사항
- [ ] 스케줄러 구현 (#RQ-0013)
- [ ] 순위 하락 감지 (#RQ-0009)
- [ ] AI 개선 제안 연동 (#RQ-0010)
- [ ] 단위 테스트 작성
- [ ] API 문서화 (Swagger)